### PR TITLE
Fix unsafe unowned reference

### DIFF
--- a/Sources/ImageViewer_swift/ImageCarouselViewController.swift
+++ b/Sources/ImageViewer_swift/ImageCarouselViewController.swift
@@ -7,7 +7,7 @@ public protocol ImageDataSource: AnyObject {
 
 public class ImageCarouselViewController:UIPageViewController, ImageViewerTransitionViewControllerConvertible {
     
-    unowned var initialSourceView: UIImageView?
+    weak var initialSourceView: UIImageView?
     var sourceView: UIImageView? {
         guard let vc = viewControllers?.first as? ImageViewerController else {
             return nil


### PR DESCRIPTION
Accessing this `unowned` reference can crash if `initialSourceView` has not been strongly held elsewhere (ie. the image view was removed from the view hierarchy while the image viewer is presented).