### PR TITLE
fix: prevent app from freezing if image never loads

### DIFF
--- a/Sources/ImageViewer_swift/ImageCarouselViewController.swift
+++ b/Sources/ImageViewer_swift/ImageCarouselViewController.swift
@@ -6,7 +6,8 @@ public protocol ImageDataSource: AnyObject {
 }
 
 public class ImageCarouselViewController:UIPageViewController, ImageViewerTransitionViewControllerConvertible {
-    
+    var imageObservation: NSKeyValueObservation?
+
     unowned var initialSourceView: UIImageView?
     var sourceView: UIImageView? {
         guard let vc = viewControllers?.first as? ImageViewerController else {
@@ -156,7 +157,8 @@ public class ImageCarouselViewController:UIPageViewController, ImageViewerTransi
         applyOptions()
         
         dataSource = self
-
+        delegate = self
+        
         if let imageDatasource = imageDatasource {
             let initialVC:ImageViewerController = .init(
                 index: initialIndex,
@@ -220,5 +222,18 @@ extension ImageCarouselViewController:UIPageViewControllerDataSource {
             index: newIndex,
             imageItem: imageDatasource.imageItem(at: newIndex),
             imageLoader: vc.imageLoader)
+    }
+}
+
+extension ImageCarouselViewController: UIPageViewControllerDelegate {
+    public func pageViewController(_ pageViewController: UIPageViewController, didFinishAnimating finished: Bool, previousViewControllers: [UIViewController], transitionCompleted completed: Bool) {
+        if completed {
+            imageObservation?.invalidate()
+            imageObservation = nil
+            if let dummyViews = view.superview?.subviews.filter({ $0 is UIImageView && $0 != targetView && $0 != sourceView }), !dummyViews.isEmpty {  
+                dummyViews.forEach { $0.removeFromSuperview() }
+            }
+            
+        }
     }
 }

--- a/Sources/ImageViewer_swift/ImageViewerTransitionPresentationManager.swift
+++ b/Sources/ImageViewer_swift/ImageViewerTransitionPresentationManager.swift
@@ -15,6 +15,9 @@ protocol ImageViewerTransitionViewControllerConvertible {
     
     // The final view
     var targetView: UIImageView? { get }
+    
+    // Store image observation
+    var imageObservation: NSKeyValueObservation? { get set }
 }
 
 final class ImageViewerTransitionPresentationAnimator:NSObject {
@@ -81,7 +84,7 @@ extension ImageViewerTransitionPresentationAnimator: UIViewControllerAnimatedTra
         completed: @escaping((Bool) -> Void)) {
 
         guard
-            let transitionVC = controller as? ImageViewerTransitionViewControllerConvertible,
+            var transitionVC = controller as? ImageViewerTransitionViewControllerConvertible,
             let sourceView = transitionVC.sourceView
         else { return }
     
@@ -99,17 +102,22 @@ extension ImageViewerTransitionPresentationAnimator: UIViewControllerAnimatedTra
         dummyImageView.tintColor = sourceView.tintColor
         transitionView.addSubview(dummyImageView)
         
+        
         UIView.animate(withDuration: duration, animations: {
             dummyImageView.frame = UIScreen.main.bounds
             controller.view.alpha = 1.0
-        }) { [weak self] finished in
-            self?.observation = transitionVC.targetView?.observe(\.image, options: [.new, .initial]) { img, change in
+        }) { finished in
+                
+            let observation = transitionVC.targetView?.observe(\.image, options: [.new, .initial]) { img, change in
                 if img.image != nil {
-                    transitionVC.targetView?.alpha = 1.0
-                    dummyImageView.removeFromSuperview()
-                    completed(finished)
+                    DispatchQueue.main.async {
+                        transitionVC.targetView?.alpha = 1.0
+                        dummyImageView.removeFromSuperview()
+                    }
                 }
             }
+            transitionVC.imageObservation = observation
+            completed(finished)
         }
     }
     


### PR DESCRIPTION
Great library, thank you!. We’ve found an issue where presentAnimation never finishes and therefore freezes the app when an image never successfully loads. 

This PR contains some changes to circumvent that. If anyone see any issue or have any suggestions for improvements please let me know.